### PR TITLE
Fix album art not dimming when paused

### DIFF
--- a/com.dreadheadhippy.ampdeckplus.sdPlugin/plugin.js
+++ b/com.dreadheadhippy.ampdeckplus.sdPlugin/plugin.js
@@ -2110,13 +2110,13 @@
         ctx.fillStyle = COLORS.BLACK;
         ctx.fillRect(0, 0, CANVAS.BUTTON_SIZE, CANVAS.BUTTON_SIZE);
 
-        const isDimmed = state.playbackState === 'stopped';
+        const isDimmed = state.playbackState !== 'playing';
 
         if (state.currentAlbumArt) {
             const img = new Image();
             img.onload = () => {
                 ctx.drawImage(img, 0, 0, CANVAS.BUTTON_SIZE, CANVAS.BUTTON_SIZE);
-                
+
                 // Apply gray overlay when paused or stopped
                 if (isDimmed) {
                     ctx.fillStyle = 'rgba(128, 128, 128, 0.6)';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ampdeckplus",
-  "version": "2.0.14",
+  "version": "2.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ampdeckplus",
-      "version": "2.0.14",
+      "version": "2.0.18",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.3",

--- a/src/ui/buttonRenderer.js
+++ b/src/ui/buttonRenderer.js
@@ -44,13 +44,13 @@ export function renderAlbumArt(context) {
     ctx.fillStyle = COLORS.BLACK;
     ctx.fillRect(0, 0, CANVAS.BUTTON_SIZE, CANVAS.BUTTON_SIZE);
 
-    const isDimmed = state.playbackState === 'stopped';
+    const isDimmed = state.playbackState !== 'playing';
 
     if (state.currentAlbumArt) {
         const img = new Image();
         img.onload = () => {
             ctx.drawImage(img, 0, 0, CANVAS.BUTTON_SIZE, CANVAS.BUTTON_SIZE);
-            
+
             // Apply gray overlay when paused or stopped
             if (isDimmed) {
                 ctx.fillStyle = 'rgba(128, 128, 128, 0.6)';


### PR DESCRIPTION
Fixes #14 

Noticed the album art button stays at full color when playback is paused. The comment in `renderAlbumArt` says the overlay should apply "when paused or stopped," but the guard only checks for `stopped`.

`playbackState` can be `playing`, `paused`, `stopped`, or `idle` so `paused` slips through.

Changing the check to `!== `'playing'` so the overlay will fire in any non-playing state.

### Playing
<img width="418" height="209" alt="image" src="https://github.com/user-attachments/assets/9684aa38-7d82-469f-86d8-804024bd9c82" />

### Paused
<img width="383" height="203" alt="image" src="https://github.com/user-attachments/assets/b002cf91-010a-4726-a1af-e971367ce998" />

### No tracks remain
<img width="376" height="177" alt="image" src="https://github.com/user-attachments/assets/f06ea406-6b2b-4899-9cc6-f00c1720dfb4" />
