### PR TITLE
Reset queue position after playing item

### DIFF
--- a/com.dreadheadhippy.ampdeckplus.sdPlugin/plugin.js
+++ b/com.dreadheadhippy.ampdeckplus.sdPlugin/plugin.js
@@ -4793,11 +4793,8 @@
                     '/player/playback/skipTo',
                     { key: targetItem.key, playQueueItemID: targetItem.playQueueItemID }
                 )
-                    .then(() => loadQueueItems(context, { forceRefresh: true }))
-                    .catch(err => {
-                        logger.warn(`Queue skip failed: ${err.message}`);
-                        loadQueueItems(context, { forceRefresh: true });
-                    });
+                    .catch(err => logger.warn(`Queue skip failed: ${err.message}`))
+                    .finally(() => loadQueueItems(context, { forceRefresh: true, resetCursor: true }));
                 return;
             }
 
@@ -4821,11 +4818,8 @@
                 ? (newItems[0].key || null)
                 : null;
             plexConnection.removeFromQueue(targetItem.queueID, targetItem.playQueueItemID)
-                .then(() => loadQueueItems(context, { forceRefresh: true }))
-                .catch(err => {
-                    logger.warn(`Queue removal failed: ${err.message}`);
-                    loadQueueItems(context, { forceRefresh: true });
-                });
+                .catch(err => logger.warn(`Queue removal failed: ${err.message}`))
+                .finally(() => loadQueueItems(context, { forceRefresh: true }));
         }
     }
 
@@ -4992,7 +4986,7 @@
     // SETTINGS MANAGEMENT
     // ============================================
 
-    async function loadQueueItems(context, { forceRefresh = false, currentRatingKey = null } = {}) {
+    async function loadQueueItems(context, { forceRefresh = false, currentRatingKey = null, resetCursor = false } = {}) {
         const containerKey = state.currentContainerKey;
         if (!containerKey || !containerKey.startsWith('/playQueues/')) {
             delete queueItemsCache[context];
@@ -5038,7 +5032,9 @@
             const upNextWithQueueID = upNext.map(i => ({ ...i, queueID }));
 
             const fresh     = state.getQueueBrowserState(context);
-            const newCursor = Math.min(fresh?.cursorIndex || 0, Math.max(0, upNextWithQueueID.length - 1));
+            const newCursor = resetCursor
+                ? 0
+                : Math.min(fresh?.cursorIndex || 0, Math.max(0, upNextWithQueueID.length - 1));
             state.setQueueBrowserState(context, { items: upNextWithQueueID, cursorIndex: newCursor });
             queueItemsCache[context] = containerKey; // mark as loaded
             logger.info(`Queue browser: loaded ${upNextWithQueueID.length} up-next items`);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -610,11 +610,8 @@ function onDialUp(data) {
                 '/player/playback/skipTo',
                 { key: targetItem.key, playQueueItemID: targetItem.playQueueItemID }
             )
-                .then(() => loadQueueItems(context, { forceRefresh: true }))
-                .catch(err => {
-                    logger.warn(`Queue skip failed: ${err.message}`);
-                    loadQueueItems(context, { forceRefresh: true });
-                });
+                .catch(err => logger.warn(`Queue skip failed: ${err.message}`))
+                .finally(() => loadQueueItems(context, { forceRefresh: true, resetCursor: true }));
             return;
         }
 
@@ -638,11 +635,8 @@ function onDialUp(data) {
             ? (newItems[0].key || null)
             : null;
         plexConnection.removeFromQueue(targetItem.queueID, targetItem.playQueueItemID)
-            .then(() => loadQueueItems(context, { forceRefresh: true }))
-            .catch(err => {
-                logger.warn(`Queue removal failed: ${err.message}`);
-                loadQueueItems(context, { forceRefresh: true });
-            });
+            .catch(err => logger.warn(`Queue removal failed: ${err.message}`))
+            .finally(() => loadQueueItems(context, { forceRefresh: true }));
     }
 }
 
@@ -809,7 +803,7 @@ async function handleButtonAction(action, context) {
 // SETTINGS MANAGEMENT
 // ============================================
 
-async function loadQueueItems(context, { forceRefresh = false, currentRatingKey = null } = {}) {
+async function loadQueueItems(context, { forceRefresh = false, currentRatingKey = null, resetCursor = false } = {}) {
     const containerKey = state.currentContainerKey;
     if (!containerKey || !containerKey.startsWith('/playQueues/')) {
         delete queueItemsCache[context];
@@ -855,7 +849,9 @@ async function loadQueueItems(context, { forceRefresh = false, currentRatingKey 
         const upNextWithQueueID = upNext.map(i => ({ ...i, queueID }));
 
         const fresh     = state.getQueueBrowserState(context);
-        const newCursor = Math.min(fresh?.cursorIndex || 0, Math.max(0, upNextWithQueueID.length - 1));
+        const newCursor = resetCursor
+            ? 0
+            : Math.min(fresh?.cursorIndex || 0, Math.max(0, upNextWithQueueID.length - 1));
         state.setQueueBrowserState(context, { items: upNextWithQueueID, cursorIndex: newCursor });
         queueItemsCache[context] = containerKey; // mark as loaded
         logger.info(`Queue browser: loaded ${upNextWithQueueID.length} up-next items`);


### PR DESCRIPTION
Fixes #13 

Adds a new parameter to `loadQueueItems` called `resetCursor`. When set as `true` the cursor position will reset back to index 0 instead of staying at it's current position.

I also changed the dual calls to `loadQueueItems` into a `finally` block to prevent a double refresh (which likely wouldn't happen anyway).


https://github.com/user-attachments/assets/c9c35665-4794-46e3-98d0-0b3f7dcfb1a8