### PR TITLE
Now Playing Strip: respect None position and fix progress bar desync

### DIFF
--- a/com.dreadheadhippy.ampdeckplus.sdPlugin/plugin.js
+++ b/com.dreadheadhippy.ampdeckplus.sdPlugin/plugin.js
@@ -3329,7 +3329,7 @@
         const displayMode = state.getActiveDisplayMode(context) || settings.displayMode || 'artist';
         const fontSize = parseInt(settings.fontSize) || 16;
         const totalPanels = parseInt(settings.progressTotalPanels) || 3;
-        const position = parseInt(settings.progressPosition) || 1;
+        const position = parseInt(settings.progressPosition ?? 1);
 
         const textColor = getTextColor();
         const accentColor = getAccentColor();
@@ -3610,12 +3610,12 @@
 
         // Progress bar
         const totalPanels = parseInt(settings.progressTotalPanels) || 3;
-        const position    = parseInt(settings.progressPosition)    || 1;
+        const position    = parseInt(settings.progressPosition ?? 1);
         const progress    = state.displayProgress;
         const barY        = 90; // match other strip modes
-        ctx.fillStyle = COLORS.DARK_GRAY;
-        ctx.fillRect(0, barY, 200, BAR_H);
         if (position > 0 && position <= totalPanels) {
+            ctx.fillStyle = COLORS.DARK_GRAY;
+            ctx.fillRect(0, barY, 200, BAR_H);
             const segSize  = 100 / totalPanels;
             const segStart = (position - 1) * segSize;
             const segEnd   = position * segSize;
@@ -3817,12 +3817,12 @@
 
             // Progress bar at bottom
             const pgSettings = state.getActionSettings(context);
-            const totalPanels = parseInt(pgSettings.progressTotalPanels) || 1;
-            const position = parseInt(pgSettings.progressPosition) || 0;
+            const totalPanels = parseInt(pgSettings.progressTotalPanels) || 3;
+            const position = parseInt(pgSettings.progressPosition ?? 1);
             const progress = state.displayProgress;
-            ctx.fillStyle = COLORS.DARK_GRAY;
-            ctx.fillRect(0, PROG_Y, 200, PROG_H);
             if (position > 0 && position <= totalPanels) {
+                ctx.fillStyle = COLORS.DARK_GRAY;
+                ctx.fillRect(0, PROG_Y, 200, PROG_H);
                 const segSize = 100 / totalPanels;
                 const segStart = (position - 1) * segSize;
                 const segEnd = position * segSize;
@@ -4039,15 +4039,15 @@
         canvas.width = 200;
         canvas.height = 10;
         const ctx = canvas.getContext('2d');
-        
-        ctx.fillStyle = COLORS.DARK_GRAY;
-        ctx.fillRect(0, 0, 200, 10);
 
         if (position > 0 && position <= totalPanels) {
+            ctx.fillStyle = COLORS.DARK_GRAY;
+            ctx.fillRect(0, 0, 200, 10);
+
             const segSize = 100 / totalPanels;
             const segStart = (position - 1) * segSize;
             const segEnd = position * segSize;
-            
+
             if (progress > segStart) {
                 const progressInSeg = Math.min(progress, segEnd) - segStart;
                 const fillWidth = Math.round((progressInSeg / segSize) * 200);
@@ -4057,7 +4057,7 @@
                 }
             }
         }
-        
+
         return canvas.toDataURL('image/png');
     }
 

--- a/src/ui/layoutManager.js
+++ b/src/ui/layoutManager.js
@@ -54,7 +54,7 @@ export function renderStripLayout(context) {
     const displayMode = state.getActiveDisplayMode(context) || settings.displayMode || 'artist';
     const fontSize = parseInt(settings.fontSize) || 16;
     const totalPanels = parseInt(settings.progressTotalPanels) || 3;
-    const position = parseInt(settings.progressPosition) || 1;
+    const position = parseInt(settings.progressPosition ?? 1);
 
     const textColor = getTextColor();
     const accentColor = getAccentColor();
@@ -335,12 +335,12 @@ function renderQueueBrowser(context, settings, accentColor, textColor, stripSeco
 
     // Progress bar
     const totalPanels = parseInt(settings.progressTotalPanels) || 3;
-    const position    = parseInt(settings.progressPosition)    || 1;
+    const position    = parseInt(settings.progressPosition ?? 1);
     const progress    = state.displayProgress;
     const barY        = 90; // match other strip modes
-    ctx.fillStyle = COLORS.DARK_GRAY;
-    ctx.fillRect(0, barY, 200, BAR_H);
     if (position > 0 && position <= totalPanels) {
+        ctx.fillStyle = COLORS.DARK_GRAY;
+        ctx.fillRect(0, barY, 200, BAR_H);
         const segSize  = 100 / totalPanels;
         const segStart = (position - 1) * segSize;
         const segEnd   = position * segSize;
@@ -542,12 +542,12 @@ function renderPlaylistCarouselPoster(context, carousel, accentColor) {
 
         // Progress bar at bottom
         const pgSettings = state.getActionSettings(context);
-        const totalPanels = parseInt(pgSettings.progressTotalPanels) || 1;
-        const position = parseInt(pgSettings.progressPosition) || 0;
+        const totalPanels = parseInt(pgSettings.progressTotalPanels) || 3;
+        const position = parseInt(pgSettings.progressPosition ?? 1);
         const progress = state.displayProgress;
-        ctx.fillStyle = COLORS.DARK_GRAY;
-        ctx.fillRect(0, PROG_Y, 200, PROG_H);
         if (position > 0 && position <= totalPanels) {
+            ctx.fillStyle = COLORS.DARK_GRAY;
+            ctx.fillRect(0, PROG_Y, 200, PROG_H);
             const segSize = 100 / totalPanels;
             const segStart = (position - 1) * segSize;
             const segEnd = position * segSize;
@@ -764,15 +764,15 @@ function createProgressBarSegment(position, totalPanels, progress, color) {
     canvas.width = 200;
     canvas.height = 10;
     const ctx = canvas.getContext('2d');
-    
-    ctx.fillStyle = COLORS.DARK_GRAY;
-    ctx.fillRect(0, 0, 200, 10);
 
     if (position > 0 && position <= totalPanels) {
+        ctx.fillStyle = COLORS.DARK_GRAY;
+        ctx.fillRect(0, 0, 200, 10);
+
         const segSize = 100 / totalPanels;
         const segStart = (position - 1) * segSize;
         const segEnd = position * segSize;
-        
+
         if (progress > segStart) {
             const progressInSeg = Math.min(progress, segEnd) - segStart;
             const fillWidth = Math.round((progressInSeg / segSize) * 200);
@@ -782,7 +782,7 @@ function createProgressBarSegment(position, totalPanels, progress, color) {
             }
         }
     }
-    
+
     return canvas.toDataURL('image/png');
 }
 


### PR DESCRIPTION
Fixes #15 

Fixes the None position so the bar is properly removed from being drawn. Also fixes a small issue where the 4th dial slot could accidentally default to an incorrect 1 value causing the 4th progress slot to behave as if it were in the 1st position.

<img width="547" height="247" alt="image" src="https://github.com/user-attachments/assets/a3d2328c-631c-493e-866d-ab9d559a4f4a" />



<img width="580" height="612" alt="image" src="https://github.com/user-attachments/assets/c8411097-7f72-46a9-b664-8aefe8318bec" />
