### PR TITLE
feat: focus Plexamp when album art button pressed with no album

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -673,11 +673,16 @@ function onTouchTap(data) {
 
 async function handleButtonAction(action, context) {
     // PLAYLIST is allowed when stopped or idle — it launches Plexamp and starts playback.
-    if ((state.playbackState === 'stopped' || state.playbackState === 'idle') && action !== ACTIONS.PLAYLIST) return;
+    // ALBUM_ART when stopped focuses the Plexamp app instead of toggling playback.
+    if ((state.playbackState === 'stopped' || state.playbackState === 'idle') && action !== ACTIONS.PLAYLIST && action !== ACTIONS.ALBUM_ART) return;
 
     switch (action) {
         case ACTIONS.ALBUM_ART:
-            await playbackController.togglePlayPause();
+            if (state.playbackState === 'stopped' || state.playbackState === 'idle') {
+                focusPlexampApp();
+            } else {
+                await playbackController.togglePlayPause();
+            }
             break;
         case ACTIONS.PLAY_PAUSE:
             await playbackController.togglePlayPause();
@@ -797,6 +802,29 @@ async function handleButtonAction(action, context) {
     
     // Update displays after action
     setTimeout(() => updateAllDisplays(), 100);
+}
+
+// ============================================
+// PLEXAMP APP FOCUS
+// ============================================
+
+/**
+ * Focus the Plexamp application by opening its URL scheme via Stream Deck.
+ */
+function focusPlexampApp() {
+    if (!state.connection) {
+        logger.warn('Cannot focus Plexamp: no Stream Deck connection');
+        return;
+    }
+    const sent = state.connection.send({
+        event: 'openUrl',
+        payload: { url: 'plexamp://' }
+    });
+    if (sent) {
+        logger.info('Focusing Plexamp app');
+    } else {
+        logger.warn('Failed to send focus command to Stream Deck');
+    }
 }
 
 // ============================================


### PR DESCRIPTION
Hello!  I'm a big fan of AmpDeckPlus! But I don't have a lot of buttons available so mostly just use the album art button for play pause and to see what's playing. One thing that I've missed is that  when playback ends the button just shows "no album".  This change adds a little functionality where clicking the blank album art button will focuses the Plexamp app via the Stream Deck openUrl event with the plexamp:// URL scheme.

Happy to rework anything if you'd like!